### PR TITLE
Remove ci-test from git pre-commit hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
   },
   "pre-commit": {
     "run": [
-      "ci-test",
       "lint"
     ]
   },


### PR DESCRIPTION
## Purpose

The ci-test git pre-commit hook takes too long.


## Proposed Change

Remove the ci-test pre-commit hook.


## Checklist

- [x] Remove the ci-test pre-commit hook.