### PR TITLE
Save picture

### DIFF
--- a/screens/FinishedArtScreen.tsx
+++ b/screens/FinishedArtScreen.tsx
@@ -3,6 +3,8 @@ import { Text, View } from 'components/Themed'
 import Button from 'components/Button'
 import * as Sharing from 'expo-sharing'
 import type { NativeStackScreenProps } from '@react-navigation/native-stack'
+import * as MediaLibrary from 'expo-media-library'
+import * as Permissions from 'expo-permissions'
 
 const { width, height } = Dimensions.get('screen')
 const containerWidth = width * 0.8
@@ -23,14 +25,25 @@ const FinishedArtScreen: React.FC<Props> = ({ route, navigation }) => {
     }
   }
 
+  const saveImage = async () => {
+    const { status } = await MediaLibrary.requestPermissionsAsync()
+    if (status) {
+      MediaLibrary.saveToLibraryAsync(image)
+    } else {
+      console.log('Permissions denied')
+    }
+    console.log('done')
+  }
+
   const handleHome = () => navigation.navigate('Profile')
 
   return (
     <View style={styles.container}>
       <Image source={{ uri: image }} style={styles.image} />
       <View style={styles.row}>
-        <Button onPress={shareImage} style={styles.shareButton} title="Share" />
-        <Button onPress={handleHome} style={styles.shareButton} title="Home" />
+        <Button onPress={shareImage} style={styles.actionButtons} title="Share" />
+        <Button onPress={saveImage} style={styles.actionButtons} title="Save" />
+        <Button onPress={handleHome} style={styles.actionButtons} title="Home" />
       </View>
     </View>
   )
@@ -54,5 +67,5 @@ const styles = StyleSheet.create({
     height: containerWidth,
     marginBottom: 10,
   },
-  shareButton: { alignSelf: 'center', width: containerWidth / 2 - 20, marginTop: 20, marginHorizontal: 10 },
+  actionButtons: { alignSelf: 'center', width: containerWidth / 2 - 20, marginTop: 20, marginHorizontal: 10 },
 })

--- a/screens/FinishedArtScreen.tsx
+++ b/screens/FinishedArtScreen.tsx
@@ -4,6 +4,7 @@ import Button from 'components/Button'
 import * as Sharing from 'expo-sharing'
 import type { NativeStackScreenProps } from '@react-navigation/native-stack'
 import * as MediaLibrary from 'expo-media-library'
+import { useState } from 'react'
 
 const { width, height } = Dimensions.get('screen')
 const containerWidth = width * 0.8
@@ -17,6 +18,7 @@ type Props = NativeStackScreenProps<RootStackParamList, 'FinishedArtScreen'>
 
 const FinishedArtScreen: React.FC<Props> = ({ route, navigation }) => {
   const { image } = route.params
+  const [saved, setSaved] = useState(false)
 
   const shareImage = async () => {
     if (await Sharing.isAvailableAsync()) {
@@ -28,11 +30,9 @@ const FinishedArtScreen: React.FC<Props> = ({ route, navigation }) => {
     const { status } = await MediaLibrary.requestPermissionsAsync()
     if (status) {
       const asset = await MediaLibrary.createAssetAsync(image)
-      asset.filename = '@PY-' + new Date().toLocaleTimeString()
+      // asset.filename = '@PY-' + new Date().toLocaleTimeString()
       const albumCreated = await MediaLibrary.createAlbumAsync('Paint-Yourself', asset, false)
-      console.log(albumCreated)
-
-      console.log(asset.filename)
+      setSaved(true)
     } else {
       console.log('Permissions denied')
     }
@@ -46,9 +46,11 @@ const FinishedArtScreen: React.FC<Props> = ({ route, navigation }) => {
       <Image source={{ uri: image }} style={styles.image} />
       <View style={styles.row}>
         <Button onPress={shareImage} style={styles.actionButtons} title="Share" />
-        <Button onPress={saveImage} style={styles.actionButtons} title="Save" />
+        <Button onPress={saveImage} style={styles.actionButtons} disabled={saved} title="Save" />
         <Button onPress={handleHome} style={styles.actionButtons} title="Home" />
       </View>
+
+      <View style={styles.savedText}>{saved && <Text>Image saved!</Text>}</View>
     </View>
   )
 }
@@ -58,18 +60,29 @@ export default FinishedArtScreen
 const styles = StyleSheet.create({
   container: {
     flex: 1,
+    width: '100%',
     alignItems: 'center',
     justifyContent: 'center',
   },
   row: {
+    width: '100%',
+    flex: 0.5,
     display: 'flex',
     flexDirection: 'row',
-    justifyContent: 'space-between',
+    justifyContent: 'space-around',
   },
   image: {
+    marginTop: 60,
+    borderWidth: 1,
+    borderColor: 'white',
+    flex: 3,
     width: containerWidth,
     height: containerWidth,
     marginBottom: 10,
   },
-  actionButtons: { alignSelf: 'center', width: containerWidth / 2 - 20, marginTop: 20, marginHorizontal: 10 },
+  actionButtons: { alignSelf: 'center', width: containerWidth / 2 - 50, marginTop: 20 },
+  savedText: {
+    flex: 0.5,
+    marginTop: 10,
+  },
 })

--- a/screens/FinishedArtScreen.tsx
+++ b/screens/FinishedArtScreen.tsx
@@ -4,7 +4,6 @@ import Button from 'components/Button'
 import * as Sharing from 'expo-sharing'
 import type { NativeStackScreenProps } from '@react-navigation/native-stack'
 import * as MediaLibrary from 'expo-media-library'
-import * as Permissions from 'expo-permissions'
 
 const { width, height } = Dimensions.get('screen')
 const containerWidth = width * 0.8
@@ -28,6 +27,12 @@ const FinishedArtScreen: React.FC<Props> = ({ route, navigation }) => {
   const saveImage = async () => {
     const { status } = await MediaLibrary.requestPermissionsAsync()
     if (status) {
+      const asset = await MediaLibrary.createAssetAsync(image)
+      const albumCreated = await MediaLibrary.createAlbumAsync('Paint-Yourself', asset)
+      console.log(albumCreated)
+
+      asset.filename = '@PY-' + new Date().toLocaleTimeString()
+      console.log(asset.filename)
       MediaLibrary.saveToLibraryAsync(image)
     } else {
       console.log('Permissions denied')

--- a/screens/FinishedArtScreen.tsx
+++ b/screens/FinishedArtScreen.tsx
@@ -28,12 +28,11 @@ const FinishedArtScreen: React.FC<Props> = ({ route, navigation }) => {
     const { status } = await MediaLibrary.requestPermissionsAsync()
     if (status) {
       const asset = await MediaLibrary.createAssetAsync(image)
-      const albumCreated = await MediaLibrary.createAlbumAsync('Paint-Yourself', asset)
+      asset.filename = '@PY-' + new Date().toLocaleTimeString()
+      const albumCreated = await MediaLibrary.createAlbumAsync('Paint-Yourself', asset, false)
       console.log(albumCreated)
 
-      asset.filename = '@PY-' + new Date().toLocaleTimeString()
       console.log(asset.filename)
-      MediaLibrary.saveToLibraryAsync(image)
     } else {
       console.log('Permissions denied')
     }

--- a/screens/ProfileScreen.tsx
+++ b/screens/ProfileScreen.tsx
@@ -1,4 +1,12 @@
-import { StyleSheet, ImageBackground, Image, Dimensions, FlatList, TouchableHighlight } from 'react-native'
+import {
+  StyleSheet,
+  ImageBackground,
+  Image,
+  Dimensions,
+  FlatList,
+  TouchableHighlight,
+  ImageSourcePropType,
+} from 'react-native'
 import React, { useEffect, useState } from 'react'
 import { Text, View } from 'components/Themed'
 import { RootTabScreenProps } from 'types'
@@ -15,7 +23,7 @@ export default function ProfileScreen({ navigation }: RootTabScreenProps<'Profil
 
   const [user] = useUserContext()
 
-  const [coverPicSrc, setCoverPicSrc] = useState('')
+  const [coverPic, setCoverPic] = useState('')
   const [numCreations, setNumCreations] = useState(0)
 
   // Array holding user's created images
@@ -50,7 +58,7 @@ export default function ProfileScreen({ navigation }: RootTabScreenProps<'Profil
     setDataSource(items)
 
     // TODO: set from persistent storage
-    setCoverPicSrc(require('../assets/images/temp/cover_photo_temp.jpg'))
+    setCoverPic(require('../assets/images/temp/cover_photo_temp.jpg'))
 
     // TODO: set from persistent storage
     setNumCreations(60)
@@ -69,7 +77,11 @@ export default function ProfileScreen({ navigation }: RootTabScreenProps<'Profil
     return (
       <View style={styles.container}>
         <View style={styles.coverRegion}>
-          <ImageBackground resizeMode="cover" source={coverPicSrc as any} style={styles.coverImage}>
+          <ImageBackground
+            resizeMode="cover"
+            source={coverPic ? (coverPic as ImageSourcePropType) : { uri: null }}
+            style={styles.coverImage}
+          >
             <View style={styles.IconButtonContainer}>
               <MaterialCommunityIcons
                 name="logout-variant"


### PR DESCRIPTION
## Purpose

User can save their stylised creations to their device

## Proposed Change

Add save button to FinishedArtScreen.tsx that saves stylised image to app folder in user's gallery (/Paint-Yourself)

## Checklist

- [x] Add Button for saving
- [x] Create album and generate image asset
- [x] Save the image
- [x] Update page styling

## Additional

Not sure if its just my phone but our custom button component's styling doesn't change opacity as expected when disabled (onClick is correctly disabled though).

Also fixed that warning for 'invalid proptype' on profile screen