### PR TITLE
Populate profile screen

### DIFF
--- a/constants/AsyncStorage.ts
+++ b/constants/AsyncStorage.ts
@@ -1,3 +1,3 @@
 export default {
-    namesKey: "@creationNames"
+  namesKey: '@creationNames',
 }

--- a/constants/AsyncStorage.ts
+++ b/constants/AsyncStorage.ts
@@ -1,0 +1,3 @@
+export default {
+    namesKey: "@creationNames"
+}

--- a/navigation/index.tsx
+++ b/navigation/index.tsx
@@ -23,6 +23,7 @@ import NewProjectScreen from 'screens/NewProjectScreen'
 import ChooseStyleScreen from 'screens/ChooseStyleScreen'
 import FinishedArtScreen from 'screens/FinishedArtScreen'
 import SettingsScreen from 'screens/SettingsScreen'
+import ExpandedImageModal from 'screens/ExpandedImageModal'
 
 const Stack = createNativeStackNavigator<RootStackParamList>()
 
@@ -48,9 +49,10 @@ export default function Navigator({ colorScheme }: { colorScheme: ColorSchemeNam
         /> */}
         <Stack.Screen name="FinishedArtScreen" component={FinishedArtScreen} options={{ headerShown: false }} />
         <Stack.Screen name="Root" component={BottomTabNavigator} options={{ headerShown: false }} />
-        {/* <Stack.Group screenOptions={{ presentation: 'modal' }}>
-        <Stack.Screen name="Modal" component={NewProjectScreen} />
-      </Stack.Group> */}
+        <Stack.Group screenOptions={{ presentation: 'modal' }}>
+          {/* <Stack.Screen name="Modal" component={NewProjectScreen} /> */}
+          <Stack.Screen name="ExpandedImageModal" component={ExpandedImageModal} options={{ headerShown: true }} />
+        </Stack.Group>
       </Stack.Navigator>
     </NavigationContainer>
   )

--- a/screens/ExpandedImageModal.tsx
+++ b/screens/ExpandedImageModal.tsx
@@ -1,0 +1,11 @@
+import React, { useEffect, useState } from 'react'
+import { Text, View } from 'components/Themed' // need view
+import { RootTabScreenProps } from 'types'
+
+export default function ExpandedImageModal({ navigation }: RootTabScreenProps<'ExpandedImageModal'>) {
+  return (
+    <View>
+      <Text>ExpandedImageModal</Text>
+    </View>
+  )
+}

--- a/screens/ExpandedImageModal.tsx
+++ b/screens/ExpandedImageModal.tsx
@@ -19,7 +19,6 @@ const ExpandedImageModal: React.FC<Props> = ({ route, navigation }) => {
 
   return (
     <View>
-      {/* <Text>Filepath: {filepath ? filepath : '<none>'}</Text> */}
       {filepath && <Image source={{ uri: filepath }} style={{ width: '100%', height: '100%' }}></Image>}
       {!filepath && <Text>(No filepath supplied)</Text>}
     </View>

--- a/screens/ExpandedImageModal.tsx
+++ b/screens/ExpandedImageModal.tsx
@@ -1,16 +1,17 @@
 import React, { useEffect } from 'react'
+import { Image } from 'react-native'
 import { Text, View } from 'components/Themed' // need view
 import { RootTabScreenProps } from 'types'
 import type { NativeStackScreenProps } from '@react-navigation/native-stack'
 
 type RootStackParamList = {
-  ExpandedImageModal: { name: string }
+  ExpandedImageModal: { name: string; filepath: string }
 }
 
 type Props = NativeStackScreenProps<RootStackParamList, 'ExpandedImageModal'>
 
 const ExpandedImageModal: React.FC<Props> = ({ route, navigation }) => {
-  const { name } = route.params
+  const { name, filepath } = route.params
 
   useEffect(() => {
     navigation.setOptions({ headerTitle: name })
@@ -18,7 +19,9 @@ const ExpandedImageModal: React.FC<Props> = ({ route, navigation }) => {
 
   return (
     <View>
-      <Text>ExpandedImageModal</Text>
+      {/* <Text>Filepath: {filepath ? filepath : '<none>'}</Text> */}
+      {filepath && <Image source={{ uri: filepath }} style={{ width: '100%', height: '100%' }}></Image>}
+      {!filepath && <Text>(No filepath supplied)</Text>}
     </View>
   )
 }

--- a/screens/ExpandedImageModal.tsx
+++ b/screens/ExpandedImageModal.tsx
@@ -3,10 +3,6 @@ import { Text, View } from 'components/Themed' // need view
 import { RootTabScreenProps } from 'types'
 import type { NativeStackScreenProps } from '@react-navigation/native-stack'
 
-// interface Props {
-//   title: string
-//   navigation: RootTabScreenProps<'ExpandedImageModal'>
-// }
 type RootStackParamList = {
   ExpandedImageModal: { name: string }
 }

--- a/screens/ExpandedImageModal.tsx
+++ b/screens/ExpandedImageModal.tsx
@@ -1,11 +1,30 @@
-import React, { useEffect, useState } from 'react'
+import React, { useEffect } from 'react'
 import { Text, View } from 'components/Themed' // need view
 import { RootTabScreenProps } from 'types'
+import type { NativeStackScreenProps } from '@react-navigation/native-stack'
 
-export default function ExpandedImageModal({ navigation }: RootTabScreenProps<'ExpandedImageModal'>) {
+// interface Props {
+//   title: string
+//   navigation: RootTabScreenProps<'ExpandedImageModal'>
+// }
+type RootStackParamList = {
+  ExpandedImageModal: { name: string }
+}
+
+type Props = NativeStackScreenProps<RootStackParamList, 'ExpandedImageModal'>
+
+const ExpandedImageModal: React.FC<Props> = ({ route, navigation }) => {
+  const { name } = route.params
+
+  useEffect(() => {
+    navigation.setOptions({ headerTitle: name })
+  })
+
   return (
     <View>
       <Text>ExpandedImageModal</Text>
     </View>
   )
 }
+
+export default ExpandedImageModal

--- a/screens/FinishedArtScreen.tsx
+++ b/screens/FinishedArtScreen.tsx
@@ -16,9 +16,9 @@ type RootStackParamList = {
   Profile: undefined
 }
 
-type storageEntry = { [id: string]: string }
-
 type Props = NativeStackScreenProps<RootStackParamList, 'FinishedArtScreen'>
+
+type storageEntry = { [id: string]: string }
 
 const FinishedArtScreen: React.FC<Props> = ({ route, navigation }) => {
   const { image } = route.params

--- a/screens/FinishedArtScreen.tsx
+++ b/screens/FinishedArtScreen.tsx
@@ -1,4 +1,6 @@
 import { StyleSheet, Image, Dimensions, TextInput } from 'react-native'
+import AsyncStorage from '@react-native-async-storage/async-storage'
+import AS_KEYS from 'constants/AsyncStorage'
 import { Text, View } from 'components/Themed'
 import Button from 'components/Button'
 import * as Sharing from 'expo-sharing'
@@ -13,6 +15,8 @@ type RootStackParamList = {
   FinishedArtScreen: { image: string }
   Profile: undefined
 }
+
+type storageEntry = { [id: string]: string }
 
 type Props = NativeStackScreenProps<RootStackParamList, 'FinishedArtScreen'>
 
@@ -69,6 +73,8 @@ const FinishedArtScreen: React.FC<Props> = ({ route, navigation }) => {
               ? 'Untitled-' + new Date().toLocaleTimeString()
               : creationName
           console.log(`VALUE: ${value}`)
+
+          await storeCreationName(key, value)
         } else {
           console.log("Couldn't find album (?)")
         }
@@ -85,6 +91,54 @@ const FinishedArtScreen: React.FC<Props> = ({ route, navigation }) => {
       save()
     }
   }, [saving])
+
+  const storeCreationName = async (itemKey: string, itemValue: string) => {
+    try {
+      // TODO: REMOVE
+      await AsyncStorage.clear()
+      //
+
+      const storageKey = AS_KEYS.namesKey
+
+      let item = await AsyncStorage.getItem(storageKey)
+
+      if (item) {
+        // object exists
+        item = JSON.parse(item)
+
+        console.log(item)
+      } else {
+        // create storage entry
+        let value = {
+          [itemKey]: itemValue,
+        } as storageEntry
+        console.log('VALUE: ')
+        console.log(value)
+
+        // serialise it
+        const storageEntrySerialised = JSON.stringify(value)
+
+        // store it
+        await AsyncStorage.setItem(storageKey, storageEntrySerialised)
+
+        let itemAfter = await AsyncStorage.getItem(storageKey)
+        console.log('ITEM AFTER:')
+        console.log(itemAfter)
+
+        // create value
+        // let creationsObject = {
+        //   [AS_KEYS.namesKey]: value,
+        // }
+
+        // console.log('CREATIONS OBJECT:')
+        // console.log(creationsObject)
+      }
+      // await AsyncStorage.setItem('@storage_Key', value)
+    } catch (e) {
+      // error
+      console.log('Storage error: ' + e)
+    }
+  }
 
   const shareImage = async () => {
     if (await Sharing.isAvailableAsync()) {
@@ -105,6 +159,7 @@ const FinishedArtScreen: React.FC<Props> = ({ route, navigation }) => {
         <Button onPress={shareImage} style={styles.actionButtons} disabled={saving} title="Share" />
         <Button onPress={handleHome} style={styles.actionButtons} disabled={saving} title="Home" />
       </View>
+      <Text style={{ color: 'white' }}>Save your creation to your gallery:</Text>
       <View style={styles.saveContainer}>
         <TextInput
           style={styles.textInput}

--- a/screens/FinishedArtScreen.tsx
+++ b/screens/FinishedArtScreen.tsx
@@ -95,7 +95,7 @@ const FinishedArtScreen: React.FC<Props> = ({ route, navigation }) => {
   const storeCreationName = async (itemKey: string, itemValue: string) => {
     try {
       // TODO: REMOVE
-      await AsyncStorage.clear()
+      // await AsyncStorage.clear()
       //
 
       const storageKey = AS_KEYS.namesKey
@@ -104,9 +104,12 @@ const FinishedArtScreen: React.FC<Props> = ({ route, navigation }) => {
 
       if (item) {
         // object exists
-        item = JSON.parse(item)
+        let itemParsed = JSON.parse(item) // parse it
+        itemParsed![itemKey] = itemValue // add new item
+        const storageEntrySerialised = JSON.stringify(itemParsed) // serialise it
+        await AsyncStorage.setItem(storageKey, storageEntrySerialised) // store it
 
-        console.log(item)
+        console.log(itemParsed)
       } else {
         // create storage entry
         let value = {
@@ -124,16 +127,7 @@ const FinishedArtScreen: React.FC<Props> = ({ route, navigation }) => {
         let itemAfter = await AsyncStorage.getItem(storageKey)
         console.log('ITEM AFTER:')
         console.log(itemAfter)
-
-        // create value
-        // let creationsObject = {
-        //   [AS_KEYS.namesKey]: value,
-        // }
-
-        // console.log('CREATIONS OBJECT:')
-        // console.log(creationsObject)
       }
-      // await AsyncStorage.setItem('@storage_Key', value)
     } catch (e) {
       // error
       console.log('Storage error: ' + e)

--- a/screens/ProfileScreen.tsx
+++ b/screens/ProfileScreen.tsx
@@ -23,7 +23,7 @@ import * as MediaLibrary from 'expo-media-library'
 
 export default function ProfileScreen({ navigation }: RootTabScreenProps<'Profile'>) {
   const IMGS_PER_ROW = 3
-  const GRID_IMG_WIDTH = Dimensions.get('window').width / IMGS_PER_ROW
+  const GRID_IMG_WIDTH = (Dimensions.get('window').width * 0.95) / IMGS_PER_ROW
   const GRID_IMG_HEIGHT = GRID_IMG_WIDTH // square images
   let creations = []
 
@@ -235,6 +235,7 @@ export default function ProfileScreen({ navigation }: RootTabScreenProps<'Profil
           <View style={styles.creationsContainer}>
             {numCreations > 0 && (
               <FlatList
+                columnWrapperStyle={{ flex: 1, justifyContent: 'space-around' }}
                 numColumns={IMGS_PER_ROW}
                 data={dataSource}
                 refreshControl={
@@ -253,7 +254,7 @@ export default function ProfileScreen({ navigation }: RootTabScreenProps<'Profil
                   return (
                     <View
                       style={{
-                        flex: 1,
+                        // flex: 1,
                         flexDirection: 'column',
                         margin: 1,
                       }}
@@ -263,8 +264,12 @@ export default function ProfileScreen({ navigation }: RootTabScreenProps<'Profil
                           style={[
                             styles.imageThumbnail,
                             {
-                              width: GRID_IMG_WIDTH - GRID_IMG_WIDTH / 9,
-                              height: GRID_IMG_HEIGHT - GRID_IMG_HEIGHT / 9,
+                              // width: GRID_IMG_WIDTH - GRID_IMG_WIDTH / 9,
+                              // height: GRID_IMG_HEIGHT - GRID_IMG_HEIGHT / 9,
+                              width: GRID_IMG_WIDTH,
+                              height: GRID_IMG_HEIGHT,
+                              // borderColor: 'red',
+                              // borderWidth: 1,
                             },
                           ]}
                           source={{
@@ -395,7 +400,8 @@ const styles = StyleSheet.create({
     // backgroundColor: 'white',
     // borderColor: 'purple',
     borderWidth: 1,
-    padding: 10,
+    // padding: 10,
+    marginTop: 10,
   },
   googleName: {
     flex: 37.5,
@@ -410,7 +416,7 @@ const styles = StyleSheet.create({
     // backgroundColor: '#393E46',
     backgroundColor: 'white',
     // borderWidth: 1,
-    padding: 5,
+    padding: '1%',
   },
   imageThumbnail: {
     justifyContent: 'center',

--- a/screens/ProfileScreen.tsx
+++ b/screens/ProfileScreen.tsx
@@ -251,6 +251,13 @@ export default function ProfileScreen({ navigation }: RootTabScreenProps<'Profil
                     }}
                   />
                 }
+                ListHeaderComponent={() => {
+                  return (
+                    <View style={{ backgroundColor: '#30363d', paddingBottom: 6, paddingRight: 6 }}>
+                      <Text style={{ textAlign: 'right', color: 'rgba(255,255,255,0.7)' }}>Pull to refresh</Text>
+                    </View>
+                  )
+                }}
                 renderItem={({ item }) => {
                   return (
                     <View

--- a/screens/ProfileScreen.tsx
+++ b/screens/ProfileScreen.tsx
@@ -75,6 +75,7 @@ export default function ProfileScreen({ navigation }: RootTabScreenProps<'Profil
           sortBy: ['creationTime'],
         })
         const assets = pagedAssets.assets
+        console.log(assets)
 
         creations = assets.map((asset, i) => {
           return {
@@ -235,7 +236,7 @@ export default function ProfileScreen({ navigation }: RootTabScreenProps<'Profil
           <View style={styles.creationsContainer}>
             {numCreations > 0 && (
               <FlatList
-                columnWrapperStyle={{ flex: 1, justifyContent: 'space-around' }}
+                columnWrapperStyle={{ flex: 1, justifyContent: 'flex-start' }}
                 numColumns={IMGS_PER_ROW}
                 data={dataSource}
                 refreshControl={
@@ -264,12 +265,8 @@ export default function ProfileScreen({ navigation }: RootTabScreenProps<'Profil
                           style={[
                             styles.imageThumbnail,
                             {
-                              // width: GRID_IMG_WIDTH - GRID_IMG_WIDTH / 9,
-                              // height: GRID_IMG_HEIGHT - GRID_IMG_HEIGHT / 9,
                               width: GRID_IMG_WIDTH,
                               height: GRID_IMG_HEIGHT,
-                              // borderColor: 'red',
-                              // borderWidth: 1,
                             },
                           ]}
                           source={{
@@ -322,7 +319,7 @@ export default function ProfileScreen({ navigation }: RootTabScreenProps<'Profil
                     flex: 1,
                   }}
                 >
-                  <Text style={{ color: 'black', flex: 1, textAlign: 'center' }}>No Creations Found!</Text>
+                  <Text style={{ color: 'black', flex: 1, textAlign: 'center' }}>No Saved Creations Found!</Text>
                   <Text style={{ color: 'black', flex: 1, textAlign: 'center' }}>
                     Tap <Text style={{ fontWeight: 'bold', color: 'black' }}>'New Project'</Text> below to get started
                     or <Text style={{ fontWeight: 'bold', color: 'black' }}>pull to refresh</Text>.
@@ -413,14 +410,18 @@ const styles = StyleSheet.create({
   },
   grid: {
     // borderColor: "cyan",
-    // backgroundColor: '#393E46',
-    backgroundColor: 'white',
+    backgroundColor: '#30363d',
+    // backgroundColor: 'white',
+    borderWidth: 5,
+    borderColor: '#30363d',
     // borderWidth: 1,
-    padding: '1%',
+    // padding: '1%',
   },
   imageThumbnail: {
     justifyContent: 'center',
     alignItems: 'center',
+    borderColor: 'grey',
+    borderWidth: 1,
     // height: 128,
     // width: 128,
   },

--- a/screens/ProfileScreen.tsx
+++ b/screens/ProfileScreen.tsx
@@ -28,7 +28,7 @@ export default function ProfileScreen({ navigation }: RootTabScreenProps<'Profil
   const GRID_IMG_WIDTH = (Dimensions.get('window').width * 0.95) / IMGS_PER_ROW
   const GRID_IMG_HEIGHT = GRID_IMG_WIDTH // square images
   let creations = []
-  let creationNames = {}
+  // let creationNames = {}
 
   const [user] = useUserContext()
 
@@ -189,9 +189,9 @@ export default function ProfileScreen({ navigation }: RootTabScreenProps<'Profil
   }
 
   // expand image selected from grid
-  const expandImageView = (filepath: string) => {
+  const expandImageView = (filepath: string, creationName: string) => {
     // console.log(`Expand grid image ${id}`)
-    navigation.navigate('ExpandedImageModal', { name: filepath } as never)
+    navigation.navigate('ExpandedImageModal', { name: creationName, filepath: filepath } as never)
   }
 
   if (user) {
@@ -307,7 +307,7 @@ export default function ProfileScreen({ navigation }: RootTabScreenProps<'Profil
                         margin: 1,
                       }}
                     >
-                      <TouchableHighlight onPress={() => expandImageView(item.name)}>
+                      <TouchableHighlight onPress={() => expandImageView(item.src, item.name)}>
                         <Image
                           style={[
                             styles.imageThumbnail,

--- a/screens/ProfileScreen.tsx
+++ b/screens/ProfileScreen.tsx
@@ -152,6 +152,7 @@ export default function ProfileScreen({ navigation }: RootTabScreenProps<'Profil
   // expand image selected from grid
   const expandImageView = (id: number) => {
     console.log(`Expand grid image ${id}`)
+    navigation.navigate('ExpandedImageModal')
   }
 
   if (user) {

--- a/screens/ProfileScreen.tsx
+++ b/screens/ProfileScreen.tsx
@@ -55,17 +55,33 @@ export default function ProfileScreen({ navigation }: RootTabScreenProps<'Profil
       const mediaPerm = await MediaLibrary.requestPermissionsAsync(false) // check first
 
       if (!mediaPerm.canAskAgain || mediaPerm.status === 'denied') {
-        /**
-         *   Code to open device setting then the user can manually grant the app
-         *  that permission
-         */
         console.log('Denied')
         setPermissionsModalActive(true)
-      } else {
-        if (mediaPerm.status === 'granted') {
-          // Your actually code require this permission
-          console.log('Granted')
+      } else if (mediaPerm.status === 'granted') {
+        // Your actually code require this permission
+        console.log('Granted')
+
+        const albums = await MediaLibrary.getAlbumsAsync()
+        console.log(albums)
+
+        let paintYourselfAlbum = null
+        for (const album of albums) {
+          if (album.hasOwnProperty('title') && album['title'] == 'Paint-Yourself') {
+            paintYourselfAlbum = album
+            break
+          }
         }
+
+        if (paintYourselfAlbum) {
+          console.log(paintYourselfAlbum.assetCount)
+          setNumCreations(paintYourselfAlbum.assetCount)
+          const assets = await MediaLibrary.getAssetsAsync({ album: paintYourselfAlbum })
+          console.log(assets)
+        } else {
+          console.log('No Paint-Yourself album found')
+        }
+      } else {
+        console.log('Unexpected error with permissions')
       }
 
       // if (status) {
@@ -79,7 +95,7 @@ export default function ProfileScreen({ navigation }: RootTabScreenProps<'Profil
     getLocalImages()
     // init temp images
     //  TODO: init this array using saved images
-    let items = Array.apply(null, Array(60)).map((v, i) => {
+    let items = Array.apply(null, Array(numCreations)).map((v, i) => {
       return {
         id: i,
         src: `http://placehold.it/${GRID_IMG_WIDTH}x${GRID_IMG_HEIGHT}?text=` + (i + 1),
@@ -92,7 +108,7 @@ export default function ProfileScreen({ navigation }: RootTabScreenProps<'Profil
     setCoverPic(require('../assets/images/temp/cover_photo_temp.jpg'))
 
     // TODO: set from persistent storage
-    setNumCreations(60)
+    // setNumCreations(0)
   }, [])
 
   const updateCoverPhoto = () => {
@@ -108,7 +124,7 @@ export default function ProfileScreen({ navigation }: RootTabScreenProps<'Profil
     return (
       <View style={styles.container}>
         <Modal
-          animationType="slide"
+          animationType="fade"
           transparent={true}
           visible={permissionsModalActive}
           onRequestClose={() => {
@@ -125,13 +141,17 @@ export default function ProfileScreen({ navigation }: RootTabScreenProps<'Profil
                 <Text style={[styles.modalText, { fontWeight: 'bold' }]}>Media Library</Text>
                 <Text style={styles.modalText}> to load your previously saved creations! </Text>
               </Text>
-
               <Text style={styles.modalText}>
                 Please go to your
-                <Text style={[styles.modalText, { fontWeight: 'bold' }]}> device settings</Text>
-                <Text style={styles.modalText}> and grant this permission. </Text>
+                <Text style={[styles.modalText, { fontWeight: 'bold' }]}> Device Settings</Text>
+                <Text style={styles.modalText}> to grant this permission. </Text>
               </Text>
-              <Pressable style={[styles.button, styles.buttonClose]} onPress={() => setPermissionsModalActive(false)}>
+              <Pressable
+                style={[styles.button, styles.buttonClose]}
+                onPress={async () => {
+                  setPermissionsModalActive(false)
+                }}
+              >
                 <Text style={styles.textStyle}>Okay!</Text>
               </Pressable>
             </View>
@@ -146,7 +166,7 @@ export default function ProfileScreen({ navigation }: RootTabScreenProps<'Profil
             <View style={styles.IconButtonContainer}>
               <MaterialCommunityIcons
                 name="logout-variant"
-                size={22}
+                size={20}
                 color="black"
                 onPress={onPressLogout}
                 style={styles.logoutButton}
@@ -277,7 +297,7 @@ const styles = StyleSheet.create({
     flex: 1,
     // borderColor: "purple",
     // backgroundColor: '#222831',
-    backgroundColor: 'white',
+    // backgroundColor: 'white',
     // borderWidth: 1,
     padding: 10,
   },
@@ -308,6 +328,7 @@ const styles = StyleSheet.create({
     fontSize: 14,
     textAlign: 'center',
     paddingTop: 8,
+    color: 'black',
     // borderColor: "cyan",
     // borderWidth: 1,
   },
@@ -338,7 +359,7 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     // borderColor: "green",
     // backgroundColor: '#222831',
-    backgroundColor: 'white',
+    // backgroundColor: 'white',
     // borderWidth: 1,
     alignItems: 'center',
     justifyContent: 'space-around',
@@ -358,7 +379,7 @@ const styles = StyleSheet.create({
   },
   profileImgContainer: {
     // backgroundColor: '#222831',
-    backgroundColor: 'white',
+    // backgroundColor: 'white',
     flex: 25,
     alignItems: 'center',
     // borderColor: "red",

--- a/screens/ProfileScreen.tsx
+++ b/screens/ProfileScreen.tsx
@@ -28,7 +28,6 @@ export default function ProfileScreen({ navigation }: RootTabScreenProps<'Profil
   const GRID_IMG_WIDTH = (Dimensions.get('window').width * 0.95) / IMGS_PER_ROW
   const GRID_IMG_HEIGHT = GRID_IMG_WIDTH // square images
   let creations = []
-  // let creationNames = {}
 
   const [user] = useUserContext()
 
@@ -124,8 +123,6 @@ export default function ProfileScreen({ navigation }: RootTabScreenProps<'Profil
             console.log(match)
           }
         }
-
-        // creationNames = valuesParsed
       }
     } catch (e) {
       console.log('Error fetching creation names:\n ' + e)
@@ -138,6 +135,7 @@ export default function ProfileScreen({ navigation }: RootTabScreenProps<'Profil
     if (!mediaPerm.canAskAgain || mediaPerm.status === 'denied') {
       console.log('Denied')
       setPermissionsModalActive(true)
+      setRefreshingCreations(false)
     } else if (mediaPerm.status === 'granted') {
       console.log('Granted')
 
@@ -190,7 +188,6 @@ export default function ProfileScreen({ navigation }: RootTabScreenProps<'Profil
 
   // expand image selected from grid
   const expandImageView = (filepath: string, creationName: string) => {
-    // console.log(`Expand grid image ${id}`)
     navigation.navigate('ExpandedImageModal', { name: creationName, filepath: filepath } as never)
   }
 
@@ -287,7 +284,6 @@ export default function ProfileScreen({ navigation }: RootTabScreenProps<'Profil
                       setRefreshingCreations(true)
                       console.log('Refresh')
                       refreshNumCreations()
-                      // new Promise((resolve) => setTimeout(resolve, 1000)).then(() => setRefreshingCreations(false))
                     }}
                   />
                 }
@@ -341,21 +337,11 @@ export default function ProfileScreen({ navigation }: RootTabScreenProps<'Profil
 
                       setRefreshingCreations(true)
                       refreshNumCreations()
-                      // new Promise((resolve) => setTimeout(resolve, 1000)).then(() => setRefreshingCreations(false))
                     }}
                   />
                 }
               >
-                <View
-                  style={{
-                    flex: 1,
-                    backgroundColor: 'rgba(0, 0, 0, 0.0)',
-                    alignItems: 'center',
-                    justifyContent: 'center',
-                    width: '100%',
-                    height: '70%',
-                  }}
-                >
+                <View style={styles.noCreationsIconContainer}>
                   <FontAwesome5 name="sad-cry" size={64} color="rgba(0, 0, 0, 0.3)" />
                 </View>
                 <View
@@ -432,17 +418,10 @@ const styles = StyleSheet.create({
   coverRegion: {
     flex: 1,
     width: '100%',
-    // borderBottomWidth: 2,
     borderBottomColor: 'white',
-    // borderColor: "green",
-    // borderWidth: 1,
-    // justifyContent: "center",
   },
   creationsContainer: {
     flex: 1,
-    // backgroundColor: '#222831',
-    // backgroundColor: 'white',
-    // borderColor: 'purple',
     borderWidth: 1,
     // padding: 10,
     marginTop: 10,
@@ -505,6 +484,14 @@ const styles = StyleSheet.create({
     backgroundColor: 'white',
     borderWidth: 1,
     paddingVertical: '30%',
+  },
+  noCreationsIconContainer: {
+    flex: 1,
+    backgroundColor: 'rgba(0, 0, 0, 0.0)',
+    alignItems: 'center',
+    justifyContent: 'center',
+    width: '100%',
+    height: '70%',
   },
   numStylegans: {
     flex: 37.5,

--- a/screens/ProfileScreen.tsx
+++ b/screens/ProfileScreen.tsx
@@ -152,7 +152,7 @@ export default function ProfileScreen({ navigation }: RootTabScreenProps<'Profil
   // expand image selected from grid
   const expandImageView = (id: number) => {
     console.log(`Expand grid image ${id}`)
-    navigation.navigate('ExpandedImageModal')
+    navigation.navigate('ExpandedImageModal', { name: id.toString() } as never)
   }
 
   if (user) {

--- a/screens/ProfileScreen.tsx
+++ b/screens/ProfileScreen.tsx
@@ -49,7 +49,11 @@ export default function ProfileScreen({ navigation }: RootTabScreenProps<'Profil
     navigation.navigate('LoginRegister')
   })
 
+  useEffect(() => {}, [numCreations])
+
   useEffect(() => {
+    let creations
+
     // load previously saved images from /Paint-Yourself
     const getLocalImages = async () => {
       const mediaPerm = await MediaLibrary.requestPermissionsAsync(false) // check first
@@ -58,10 +62,10 @@ export default function ProfileScreen({ navigation }: RootTabScreenProps<'Profil
         console.log('Denied')
         setPermissionsModalActive(true)
       } else if (mediaPerm.status === 'granted') {
-        // Your actually code require this permission
         console.log('Granted')
 
         const albums = await MediaLibrary.getAlbumsAsync()
+        console.log(`ALBUMS: `)
         console.log(albums)
 
         let paintYourselfAlbum = null
@@ -75,21 +79,32 @@ export default function ProfileScreen({ navigation }: RootTabScreenProps<'Profil
         if (paintYourselfAlbum) {
           console.log(paintYourselfAlbum.assetCount)
           setNumCreations(paintYourselfAlbum.assetCount)
-          const assets = await MediaLibrary.getAssetsAsync({ album: paintYourselfAlbum })
-          console.log(assets)
+          const pagedAssets = await MediaLibrary.getAssetsAsync({
+            album: paintYourselfAlbum,
+            first: numCreations,
+            mediaType: 'photo',
+            sortBy: ['creationTime'],
+          })
+          const assets = pagedAssets.assets
+          // console.log(assets)
+
+          creations = assets.map((asset, i) => {
+            return {
+              id: i,
+              src: asset.uri,
+            }
+          })
+
+          console.log(`CREATIONS: `)
+          console.log(creations)
+
+          setDataSource(creations)
         } else {
           console.log('No Paint-Yourself album found')
         }
       } else {
         console.log('Unexpected error with permissions')
       }
-
-      // if (status) {
-      //   console.log('Have profile permissions')
-      // } else {
-      //   console.log('Need profile permissions')
-      // }
-      // const status = await MediaLibrary.requestPermissionsAsync(false)
     }
 
     getLocalImages()

--- a/types.tsx
+++ b/types.tsx
@@ -15,6 +15,7 @@ declare global {
 
 export type RootStackParamList = {
   Root: NavigatorScreenParams<RootTabParamList> | undefined
+  ExpandedImageModal: undefined
   LoginRegister: undefined
   Modal: undefined
   ChooseStyleScreen: undefined
@@ -28,6 +29,7 @@ export type RootStackScreenProps<Screen extends keyof RootStackParamList> = Nati
 >
 
 export type RootTabParamList = {
+  ExpandedImageModal: undefined
   LoginRegister: undefined
   NewProject: undefined
   Profile: undefined

--- a/types.tsx
+++ b/types.tsx
@@ -16,7 +16,7 @@ declare global {
 export type RootStackParamList = {
   Root: NavigatorScreenParams<RootTabParamList> | undefined
   ExpandedImageModal: undefined
-  LoginRegister: undefined
+  LoginRegister: { title: string }
   Modal: undefined
   ChooseStyleScreen: undefined
   FinishedArtScreen: undefined


### PR DESCRIPTION
## Purpose

We need to populate the user's profile screen with their saved creations, and give them a way to view their creations again fullscreen from within the app. We also want the user to be able to name their creations as a personalisation feature.

## Proposed Change

The profile screen uses ``Expo Media Library`` to pull saved user creations from the local ``/Paint-Yourself`` folder and populates the image grid.

User enters a name when they're saving their creations. Upon saving, a new {uri: creationName} pair is appended the async storage object mapping creations to their names. When the user selects an image from the grid on the profile screen, a modal with title ``creationName`` is opened with a fullscreen view of their image.

![image](https://user-images.githubusercontent.com/20342363/156372361-7373baf6-763e-4cdb-839d-f376497cc39f.png)

![image](https://user-images.githubusercontent.com/20342363/156372397-1f3ffe55-611b-49ee-81e1-a50e0b9beaf1.png)

![image](https://user-images.githubusercontent.com/20342363/156372438-ec02742b-9259-4746-8122-4708f5dd6371.png)


## Checklist

- [x] Permissions checks for media library & error handling
  - [x] Popup modal for when user has declined permissions ("please enable in settings")
- [x] Load creations from ``/Paint-Yourself`` gallery folder to profile screen grid
  - [x] Alternate view for when user has no creations
- [x] Set up async storage to handle saving pairs of URI and creationName
- [x] Add open Modal for onPress image grid item, showing screen for creation

