### PR TITLE
Update cover photo

### DIFF
--- a/constants/AsyncStorage.ts
+++ b/constants/AsyncStorage.ts
@@ -1,3 +1,4 @@
 export default {
   namesKey: '@creationNames',
+  coverPhotoKey: "@coverPhotoUri"
 }

--- a/screens/ProfileScreen.tsx
+++ b/screens/ProfileScreen.tsx
@@ -78,7 +78,7 @@ export default function ProfileScreen({ navigation }: RootTabScreenProps<'Profil
           sortBy: ['creationTime'],
         })
         const assets = pagedAssets.assets
-        console.log(assets)
+        // console.log(assets)
 
         creations = assets.map((asset, i) => {
           return {
@@ -107,7 +107,7 @@ export default function ProfileScreen({ navigation }: RootTabScreenProps<'Profil
       // {... uri: creationName ...}
       const uriNamePairs = await AsyncStorage.getItem(namesKey)
 
-      console.log(uriNamePairs)
+      // console.log(uriNamePairs)
 
       if (uriNamePairs) {
         const uriNamePairsParsed = JSON.parse(uriNamePairs)
@@ -117,11 +117,11 @@ export default function ProfileScreen({ navigation }: RootTabScreenProps<'Profil
           match = creations.find((o) => o.src === uriKey)
 
           if (match) {
-            console.log('MATCH: ')
-            console.log(match)
+            // // console.log('MATCH: ')
+            // console.log(match)
 
             match.name = uriNamePairsParsed[uriKey]
-            console.log(match)
+            // console.log(match)
           }
         }
       }
@@ -188,8 +188,23 @@ export default function ProfileScreen({ navigation }: RootTabScreenProps<'Profil
   useEffect(() => {
     refreshNumCreations()
 
+    const getCoverPicUri = async () => {
+      try {
+        const coverPhotoUri = await AsyncStorage.getItem(AS_KEYS.coverPhotoKey)
+        if (coverPhotoUri !== null) {
+          // saved cover photo exists; load it
+          setCoverPic({ uri: coverPhotoUri })
+        }
+      } catch (e) {
+        console.log(e)
+
+        // set default profile pic
+        setCoverPic(require('../assets/images/temp/cover_photo_temp.jpg'))
+      }
+    }
+
+    getCoverPicUri()
     // TODO: set from persistent storage
-    setCoverPic(require('../assets/images/temp/cover_photo_temp.jpg'))
   }, [])
 
   const updateCoverPhoto = async () => {
@@ -202,6 +217,13 @@ export default function ProfileScreen({ navigation }: RootTabScreenProps<'Profil
     })
 
     if (!imageResponse.cancelled) {
+      // write the new uri to async storage:
+      try {
+        await AsyncStorage.setItem(AS_KEYS.coverPhotoKey, imageResponse.uri)
+      } catch (error) {
+        console.log('Unexpected error saving cover photo URI')
+      }
+
       setCoverPic({ uri: imageResponse.uri })
     }
   }

--- a/screens/ProfileScreen.tsx
+++ b/screens/ProfileScreen.tsx
@@ -20,6 +20,7 @@ import { onAuthStateChanged } from 'firebase/auth'
 import { useUserContext } from 'hooks/useUserContext'
 import { auth } from 'utils/firebase'
 import * as MediaLibrary from 'expo-media-library'
+import * as ImgPicker from 'expo-image-picker'
 import AsyncStorage from '@react-native-async-storage/async-storage'
 import AS_KEYS from 'constants/AsyncStorage'
 
@@ -191,8 +192,18 @@ export default function ProfileScreen({ navigation }: RootTabScreenProps<'Profil
     setCoverPic(require('../assets/images/temp/cover_photo_temp.jpg'))
   }, [])
 
-  const updateCoverPhoto = () => {
-    console.log('Update Cover Photo')
+  const updateCoverPhoto = async () => {
+    let imageResponse = await ImgPicker.launchImageLibraryAsync({
+      mediaTypes: ImgPicker.MediaTypeOptions.Images,
+      allowsEditing: true,
+      // aspect: [9, 16], // 8x10 portrait
+      aspect: [4, 3],
+      quality: 1,
+    })
+
+    if (!imageResponse.cancelled) {
+      setCoverPic({ uri: imageResponse.uri })
+    }
   }
 
   // expand image selected from grid


### PR DESCRIPTION
## Purpose

As a personalisation feature, the user should be able to set a cover photo image for their profile from their phone gallery.

## Proposed Change

The image button icon on the cover photo now prompts the user to select an image from their phone gallery. This image URI is written to async storage and used to load the selected image when the app is re-opened.

![image](https://user-images.githubusercontent.com/20342363/159362072-1144d761-8ce5-4918-8eb5-893a8c57c9bc.png)

## Checklist

- [x] Open image picker when cover photo button clicked
- [x] Save selected image URI to async storage so it may be loaded as cover photo on subsequent startups.